### PR TITLE
Improve estimator variance and allocation formulas

### DIFF
--- a/AcATaMa/gui/accuracy_assessment_results.py
+++ b/AcATaMa/gui/accuracy_assessment_results.py
@@ -35,6 +35,18 @@ def rf(fv, r=5):
     return round(fv, r)
 
 
+def post_stratified_variance_table(error_matrix):
+    return [
+        [
+            cell_count * (1 - cell_count / total_row) / (total_row - 1)
+            if total_row not in [0, 1]
+            else np.nan
+            for cell_count in row
+        ]
+        for total_row, row in zip([sum(r) for r in error_matrix], error_matrix, strict=True)
+    ]
+
+
 @error_handler
 def get_html(accu_asse):
     ###########################################################################
@@ -637,10 +649,7 @@ def get_html(accu_asse):
 
     # the error for post-stratified
     if accu_asse.estimator == "Simple/systematic post-stratified estimator":
-        ui_table = [
-            [(1 - i / total_row) ** 2 * i / (total_row - 1) if total_row not in [0, 1] else np.nan for i in row]
-            for total_row, row in zip([sum(r) for r in accu_asse.error_matrix], accu_asse.error_matrix, strict=True)
-        ]
+        ui_table = post_stratified_variance_table(accu_asse.error_matrix)
         wi = [accu_asse.thematic_pixels_count[value] / total_pixels_classes for value in accu_asse.values]
         variance = [
             ((1 - total_samples / total_pixels_classes) / total_samples)
@@ -1038,10 +1047,7 @@ def export_to_csv(accu_asse, file_out, csv_separator, csv_decimal_separator):
 
     # the error for post-stratified
     if accu_asse.estimator == "Simple/systematic post-stratified estimator":
-        ui_table = [
-            [(1 - i / total_row) ** 2 * i / (total_row - 1) if total_row not in [0, 1] else np.nan for i in row]
-            for total_row, row in zip([sum(r) for r in accu_asse.error_matrix], accu_asse.error_matrix, strict=True)
-        ]
+        ui_table = post_stratified_variance_table(accu_asse.error_matrix)
         wi = [accu_asse.thematic_pixels_count[value] / total_pixels_classes for value in accu_asse.values]
         variance = [
             ((1 - total_samples / total_pixels_classes) / total_samples)

--- a/AcATaMa/utils/sampling_utils.py
+++ b/AcATaMa/utils/sampling_utils.py
@@ -49,13 +49,15 @@ def get_num_samples_by_area_based_proportion(srs_table, total_std_error):
     total_pixel_count = float(sum(mask(srs_table["pixel_count"], srs_table["On"])))
     ratio_pixel_count = [p_c / total_pixel_count for p_c in mask(srs_table["pixel_count"], srs_table["On"])]
     Si = [(float(ui) * (1 - float(ui))) ** 0.5 for ui in mask(srs_table["ui"], srs_table["On"])]
-    total_num_samples = (sum(rpc * si for rpc, si in zip(ratio_pixel_count, Si, strict=True)) / total_std_error) ** 2
+    weighted_std_sum = sum(rpc * si for rpc, si in zip(ratio_pixel_count, Si, strict=True))
+    total_num_samples = (weighted_std_sum / total_std_error) ** 2
 
     num_samples = []
     idx = 0
     for item_enable in srs_table["On"]:
         if item_enable:
-            num_samples.append(str(round(ratio_pixel_count[idx] * total_num_samples)))
+            allocation_weight = ratio_pixel_count[idx] * Si[idx] / weighted_std_sum if weighted_std_sum > 0 else 0
+            num_samples.append(str(round(allocation_weight * total_num_samples)))
             idx += 1
         else:
             num_samples.append("0")


### PR DESCRIPTION
## Summary

This PR fixes two estimator-calculation issues found while reviewing the AcATaMa equation table against the implementation and cited estimator formulas.

### 1. Post-stratified area variance

The simple/systematic post-stratified estimator previously built the variance component with only the contribution from samples belonging to a reference class:

```text
n_hj * (1 - n_hj / n_h+)^2 / (n_h+ - 1)
```

For a binary class indicator inside a post-stratum, the sample variance must include both successes and failures. Algebraically:

```text
s_hj^2 = [n_hj(1 - p_hj)^2 + (n_h+ - n_hj)(0 - p_hj)^2] / (n_h+ - 1)
       = n_hj(1 - p_hj) / (n_h+ - 1)
```

where `p_hj = n_hj / n_h+`.

This PR usea a shared `post_stratified_variance_table` helper with:

```text
n_hj * (1 - n_hj / n_h+) / (n_h+ - 1)
```

This avoids underestimating post-stratified standard errors and confidence intervals, especially when `p_hj` is high.

### 2. Stratified sample allocation

The stratified sample-size helper already computed total sample size using the weighted stratum standard deviations:

```text
n = (sum_i W_i S_i / S(OA))^2
S_i = sqrt(U_i(1 - U_i))
```

However, per-stratum allocation used only mapped area proportions:

```text
n_i = round(W_i * n)
```

This meant the conjectured user accuracy `U_i` affected total sample size but not the relative allocation among strata. This PR updates allocation to:

```text
n_i = round((W_i S_i / sum_k W_k S_k) * n)
```

so per-stratum sample counts now use both mapped area proportion and expected stratum variability.

## Files changed

- `AcATaMa/gui/accuracy_assessment_results.py`
  - Adds a shared helper for post-stratified class-indicator variance components.
- `AcATaMa/utils/sampling_utils.py`
  - Keeps the existing total sample-size equation.
  - Updates per-stratum allocation to weight by `W_i S_i` rather than `W_i` alone.

## Verification

No test suite was run, per request.

Performed only non-test verification:

- Static LSP diagnostics on changed files: clean.
- Syntax-only compile checks with `python -m py_compile` on both changed modules.
- Manual standalone formula checks confirming:
  - the post-stratified binary sample-variance identity matches the implemented expression;
  - stratified allocation now changes when `S_i` differs across strata, as expected.

## Notes

Stratified sampling fixtures may also change when area-based allocation is regenerated, because per-stratum counts now include `S_i` in the allocation weights.